### PR TITLE
Deploy website on pushes to main

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -25,10 +25,6 @@ jobs:
         run: |
           (cd site && hugo)
 
-      - name: Create site tarball
-        run: |
-          tar cf site.tar -C site/public .
-
       - name: Prepare SSH key-file
         run: |
           mkdir -p ~/.ssh
@@ -37,7 +33,7 @@ jobs:
 
       - name: Deploy site on server
         run: |
-          cat site.tar | \
+          tar -c -O -C site/public . | \
             ssh -CT \
               -l "${{ secrets.SITE_USER }}" \
               -i ~/.ssh/id_ed25519 \


### PR DESCRIPTION
The web server has an ssh hook that decompresses the tar ball and puts the content in the appropriate web root.