### PR TITLE
Add hugo presubmit check

### DIFF
--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -1,0 +1,37 @@
+# Copyright 2025 The Witness Network Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Dry run Hugo build
+
+on: pull_request
+
+jobs:
+  dry-run-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install deps
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get install -qqy hugo
+
+      - name: Build hugo site
+        run: |
+          (cd site && hugo --gc)


### PR DESCRIPTION
This PR, mostly based off #4, adds a simple presubmit check which should help ensure that the checked-in hugo site is at least buildable without error.