### PR TITLE
Witness table add rgdd

### DIFF
--- a/site/content/witness-tables.md
+++ b/site/content/witness-tables.md
@@ -14,12 +14,14 @@ promise much since our witness network is a work-in-progress service.
 
 ## Testing
 
-| Operator        | Configures         | About page                               |
-| --------------- | ------------------ | ---------------------------------------- |
-| Florian Larysch | testing/log-list.1 | https://remora.n621.de                   |
-| rgdd            | testing/log-list.1 | https://www.rgdd.se/poc-witness/about    |
-| TrustFabric     | testing/log-list.1 | https://transparency.dev/witnesses/      |
+| Operator        | Configures             | About page                            |
+| --------------- | ---------------------- | ------------------------------------- |
+| Florian Larysch | [testing/log-list.1][] | https://remora.n621.de                |
+| rgdd            | [testing/log-list.1][] | https://www.rgdd.se/poc-witness/about |
+| TrustFabric     | [testing/log-list.1][] | https://transparency.dev/witnesses/   |
 
 **Warning:** these witnesses are just trying things out, or are otherwise just
 development and test witnesses that come and go, break, etc.  Let us know if
 something has not been working for a while and we will update this table.
+
+[testing/log-list.1]: https://testing.witness-network.org/log-list.1


### PR DESCRIPTION
In addition to the below I also added linking to the testing list in our table.

---

Participation request:

* Operator: rgdd
* Log list:  https://testing.witness-network.org/log-list.1
* Logs are discovered from the above list every 15m (cronjob)
* About page: https://www.rgdd.se/poc-witness/about

As described in the above (brief) about page, this is a test/dev only witness so I want to be in the testing table.

---

For history, here's what the about page says as of this PR (I should probably say something about me running litewitness etc -- will make a few tweaks later when time permits:

```
---About

This page contains information about my testing and development witness.  Please
note that this witness is NOT suitable for anything but testing and development.

rgdd.se/poc-witness is operated on a random VPS with a soft key.  The database
is sometimes reset, which means the history of previous log states is then lost.

When is it a good idea to use this witness for anything?  If you want to do
testing and development, you should find this witness available most of the
time.  I don't carry a pager, but I do get notifications if it is down.  I'm
also motivated to keep it up and working, since I develop software and maintain
specifications related to witness cosigning at my dayjob (Glasklar Teknik AB).

To get your log configured by rgdd.se/poc-witness, please participate in:

    https://witness-network.org/

I'm configuring the following test list every 15 minutes:

    https://testing.witness-network.org/log-list.1

Your log can request cosignatures via Glasklar Teknik's bastion host:

    https://bastion.glasklar.is/70b861a010f25030de6ff6a5267e0b951e70c04b20ba4a3ce41e7fba7b9b7dfc/add-checkpoint

My verification key (vkey) is:

    rgdd.se/poc-witness+db03732e+BCjJKlo6BU0xfIb8LutqerIFTWIXEA0L5n3tW3QyPFgG

Happy hacking and testing,
Rasmus Dahlberg (rgdd)
``