### PR TITLE
Add gopherwatch sumdb verifiable index testing log

### DIFF
--- a/lists/testing/log-list.1
+++ b/lists/testing/log-list.1
@@ -33,5 +33,5 @@ qpd 8640
 contact services@mullvad.net | https://serviceberry.tlog.stagemole.eu/about
 
 vkey vindex.gopherwatch.org+af4f4f3a+AYlEp21ErzmKZa+aqhjC8BQteyEtsVwmLzblkzHxn8et
-qpd 8640
+qpd 288
 contact admin@gopherwatch.org


### PR DESCRIPTION
vindex.gopherwatch.org is running https://github.com/transparency-dev/incubator/tree/main/vindex/cmd/sumdbindex. See https://vindex.gopherwatch.org/

It would be nice to get its output log witnessed, Martin added the necessary code to sumdbindex earlier today.

The vkey name is `vindex.gopherwatch.org`, but the actual tlog endpoints for the verifiable index are at https://vindex.gopherwatch.org/outputlog/. I think the vkey name can be considered "just an identifier", but ideally it would point to the actual tlog endpoint... See Martin's message in #vindex on the transparency-dev slack for more info and options.

Given the sumdb /latest refresh interval of 5 mins, I'm expecting 12 updates per hour, 288 per day. The specified qpd value is for an interval of 10s. Would it be better to set this closer to the expected rate, rather than specifying a higher value to leave room for future rate increases? I could also request an update to the qpd in the future when needed...

Let me know if discussion on the witness-network mailing list is preferred!
