### PR TITLE
Additional links for sigsum test logs

### DIFF
--- a/lists/testing/log-list.1
+++ b/lists/testing/log-list.1
@@ -20,14 +20,16 @@ vkey arche2026h1.staging.ct.transparency.dev+706e1366+AVK//LIrBodyJVW1ZUUDud5pN8
 qpd 86400
 contact google-ct-logs@googlegroups.com
 
+# https://seasalp.glasklar.is/
 vkey sigsum.org/v1/tree/4e89cc51651f0d95f3c6127c15e1a42e3ddf7046c5b17b752689c402e773bb4d+778629b1+AUZEryq9QPSJWgA7yjUPnVkSqzAaScd/E+W22QXCCl/m
 qpd 8640
-contact sigsum-logs (at) glasklarteknik.se
+contact sigsum-logs (at) glasklarteknik.se | https://git.glasklar.is/glasklar/services/sigsum-logs/-/blob/main/instances/seasalp.md
 
 vkey log2025-alpha3.rekor.sigstage.dev+d3d3a70c+AZQ93VXPMmj9uZj7U/7CefQ9yy8RgYFv6mKzOseipjqp
 qpd 86400
 contact infra-dev (at) sigstore.dev
 
+# https://serviceberry.tlog.stagemole.eu/
 vkey sigsum.org/v1/tree/1643169b32bef33a3f54f8a353b87c475d19b6223cbb106390d10a29978e1cba+57f71a6a+AUfkgWBtisunR6awU9bC0ZFgX7EiF11BChICqRQwq845
 qpd 8640
 contact services@mullvad.net | https://serviceberry.tlog.stagemole.eu/about


### PR DESCRIPTION
Add log base/frontpage URLs as a comments. Add seasalp about page URL under contact. 