### PR TITLE
log-lists/testing: Extend barreleye contact field

### DIFF
--- a/lists/testing/log-list.1
+++ b/lists/testing/log-list.1
@@ -22,7 +22,7 @@ contact google-ct-logs@googlegroups.com
 
 vkey sigsum.org/v1/tree/4e89cc51651f0d95f3c6127c15e1a42e3ddf7046c5b17b752689c402e773bb4d+778629b1+AUZEryq9QPSJWgA7yjUPnVkSqzAaScd/E+W22QXCCl/m
 qpd 8640
-contact sigsum-logs (at) glasklarteknik.se
+contact sigsum-logs (at) glasklarteknik.se | https://git.glasklar.is/glasklar/services/sigsum-logs/-/blob/main/instances/barreleye.md
 
 vkey log2025-alpha3.rekor.sigstage.dev+d3d3a70c+AZQ93VXPMmj9uZj7U/7CefQ9yy8RgYFv6mKzOseipjqp
 qpd 86400


### PR DESCRIPTION
Requested by @niels-moller in #20.  The correct link has been confirmed out of band with Elias, who initially enrolled the log to this list [1].

1: https://github.com/transparency-dev/witness-network/commit/937b34bb4dcf6fbe21533f8bd0a5d79efdc44dbf