### PR TITLE
log-lists/testing: add keyserver.geomys.org

### DIFF
--- a/lists/testing/log-list.1
+++ b/lists/testing/log-list.1
@@ -35,3 +35,7 @@ contact services@mullvad.net | https://serviceberry.tlog.stagemole.eu/about
 vkey vindex.gopherwatch.org+af4f4f3a+AYlEp21ErzmKZa+aqhjC8BQteyEtsVwmLzblkzHxn8et
 qpd 288
 contact admin@gopherwatch.org
+
+vkey keyserver.geomys.org+16b31509+ARLJ+pmTj78HzTeBj04V+LVfB+GFAQyrg54CRIju7Nn8
+qpd 1440
+contact keyserver-tlog@geomys.org


### PR DESCRIPTION
A log operated by Geomys for the upcoming keyserver demo.

Requested by myself.