### PR TITLE
Move Mullvad's log and witness to staging

### DIFF
--- a/lists/staging/log-list-10qps-4klogs.1
+++ b/lists/staging/log-list-10qps-4klogs.1
@@ -10,6 +10,6 @@
 #
 logs/v0
 
-#
-# There are no logs added to this list yet.
-#
+vkey sigsum.org/v1/tree/1643169b32bef33a3f54f8a353b87c475d19b6223cbb106390d10a29978e1cba+57f71a6a+AUfkgWBtisunR6awU9bC0ZFgX7EiF11BChICqRQwq845
+qpd 8640
+contact services@mullvad.net | https://serviceberry.tlog.stagemole.eu/about

--- a/site/content/witness-tables.md
+++ b/site/content/witness-tables.md
@@ -6,10 +6,11 @@ Not available yet.
 
 ## Staging
 
-| Operator    | Configures                                                  | About page                         | 
-| ----------- | ----------------------------------------------------------- | ---------------------------------- |
-| Geomys      | [testing/log-list.1][], [staging/log-list-10qps-4klogs.1][] | https://geomys.org/witness/navigli |
-| TrustFabric | [testing/log-list.1][], [staging/log-list-10qps-4klogs.1][] | https://transparency.dev/witnesses |       
+| Operator        | Configures                                                  | About page                         | 
+| --------------- | ----------------------------------------------------------- | ---------------------------------- |
+| Geomys          | [testing/log-list.1][], [staging/log-list-10qps-4klogs.1][] | https://geomys.org/witness/navigli |
+| Mullvad VPN AB  | [testing/log-list.1][], [staging/log-list-10qps-4klogs.1][] | https://witness.stagemole.eu/about             |
+| TrustFabric     | [testing/log-list.1][], [staging/log-list-10qps-4klogs.1][] | https://transparency.dev/witnesses |       
 
 **Warning:** these witnesses try to keep things stable and working, but can't
 promise much since our witness network is a work-in-progress service.
@@ -20,7 +21,6 @@ promise much since our witness network is a work-in-progress service.
 | --------------- | ---------------------- | ---------------------------------------------- |
 | Elias Rudberg   | [testing/log-list.1][] | https://witness1.smartit.nu/witness1/about.txt |
 | Florian Larysch | [testing/log-list.1][] | https://remora.n621.de                         |
-| Mullvad VPN AB  | [testing/log-list.1][] | https://witness.stagemole.eu/about             |
 | rgdd            | [testing/log-list.1][] | https://www.rgdd.se/poc-witness/about          |
 | TrustFabric     | [testing/log-list.1][] | https://transparency.dev/witnesses/            |
 


### PR DESCRIPTION
Add Mullvad's serviceberry.tlog.stagemole.eu to the staging list, and
move witness.stagemole.eu to the Staging table.

For barckward compatibility, the witness pulls both the testing and
staging list, and the log is not removed from the testing list.
