### PR TITLE
Add Mullvad's testing log to the testing list

### DIFF
--- a/lists/testing/log-list.1
+++ b/lists/testing/log-list.1
@@ -39,3 +39,7 @@ contact admin@gopherwatch.org
 vkey keyserver.geomys.org+16b31509+ARLJ+pmTj78HzTeBj04V+LVfB+GFAQyrg54CRIju7Nn8
 qpd 1440
 contact keyserver-tlog@geomys.org
+
+vkey sigsum.org/v1/tree/e93cb678c04cc52e4da380c4b19cfa14062032a722da254c65cbd95e7e76321d+c6279f6d+Ae3din1x8uLDUC6N8XgsRfxj5BmBw23kv3Aq2y6nVHHd
+qpd 8640
+contact services@mullvad.net | https://driftwood.tlog.devmole.eu/about


### PR DESCRIPTION
We now have a 'proper' testing sigsum log, and we'd like to include
it in the testing list.
