### PR TITLE
Add new 100qps-40klogs staging list

### DIFF
--- a/lists/staging/log-list-100qps-40klogs.1
+++ b/lists/staging/log-list-100qps-40klogs.1
@@ -1,0 +1,11 @@
+#
+# This is an experimental list where witnesses can discover logs.  The
+# work-in-progress list format is described here:
+#
+#   https://witness-network.org/log-list-format
+#
+# Witnesses that discover logs from this list should be able to persist the
+# states of 40,000 logs and support 100 add-checkpoint requests/s on average for
+# all logs combined (e.g., 100x 1qps logs would make this list of logs "full").
+#
+logs/v0

--- a/site/content/log-lists.md
+++ b/site/content/log-lists.md
@@ -1,6 +1,8 @@
 # Log lists
 
 The following log lists conform to the [log-list format](/log-list-format).
+They are maintained to be non-overlapping, so that it is meaningful to configure
+the union of multiple lists.
 
 ## Production
 
@@ -11,6 +13,7 @@ Not available yet.
 Appropriate for prototype usage and long-lived dogfooding:
 
   - [log-list-10qps-4klogs.1](https://staging.witness-network.org/log-list-10qps-4klogs.1)
+  - [log-list-100qps-40klogs.1](https://staging.witness-network.org/log-list-100qps-40klogs.1)
 
 **Warning:** these lists are mostly stable but sometimes break anyway, e.g., as
 a result of catching regressions or (right now) due to being a work in progress.

--- a/site/content/participate.md
+++ b/site/content/participate.md
@@ -107,9 +107,11 @@ Examples:
 
 ### Select log list(s)
 
-Which [log list(s)][ll] will you be configuring?  Choose between testing,
-staging, and production.  Select the largest performance profile you can
-accommodate.
+Which [log list(s)][ll] will you be configuring?
+
+Choose between testing, staging, and production.  Within testing, staging, and
+production you would typically configure all lists that your witness can
+accommodate by starting with lower performance profiles and moving upwards.
 
 (A performance profile defines the number of logs your witness can keep
 persistent state for, and how many add-checkpoint requests your witness can


### PR DESCRIPTION
We use non-overlapping lists, asking witness operators to configure the union of all lists they can accommodate (starting from lower performance profiles and moving upwards).  As maintainers we allocate logs to the most appropriate lists based on performance profile, so that the list in question doesn't fill up too quickly (i.e., to ensure that it is a good spending of witness resources when adding a log to a list).

The alternative would have been to have overlapping lists, e.g., where the 100qps list has a 10qps list as a sublist; and the 10qps list might in turn have a 1qps list as a sublist.  A participating witness would then choose the highest performance profile they can accommodate, as opposed to having to configure the union of the three different lists.

Both should work and it's mostly a matter of documentation.  But a nice property of non-overlapping lists is that they compose well as unions.  No questions about committed capacity given a list of lists.

The property of "any witness which commits to reading list X is compatible with my log" is also nice for non-overlapping lists.  The equivalent of this property with overlapping lists would have been "any witness which commits to reading list X or higher is compatible with my witness", which seems slightly more complex to explain and maintain.

We might want a higher performance profile in the future, but we're starting with 100qps-40klogs now in staging to see how it is received.

These additions were co-authored with Al, thanks!