### PR TITLE
Add markovianprotocol and whisper logs to testing list

### DIFF
--- a/lists/testing/log-list.1
+++ b/lists/testing/log-list.1
@@ -43,3 +43,11 @@ contact keyserver-tlog@geomys.org
 vkey sigsum.org/v1/tree/e93cb678c04cc52e4da380c4b19cfa14062032a722da254c65cbd95e7e76321d+c6279f6d+Ae3din1x8uLDUC6N8XgsRfxj5BmBw23kv3Aq2y6nVHHd
 qpd 8640
 contact services@mullvad.net | https://driftwood.tlog.devmole.eu/about
+
+vkey markovianprotocol.com/log+0302c6c8+ATkpOWo95UuEiW2EhNZAol4f0CS8hMluJfPcTSzrr03v
+qpd 24
+contact hello@markovianprotocol.com
+
+vkey whisper.online/ledger+8a3a5df0+AackwSi920iTu5AW3cOBaibI0RFtt4zT9Ox8mygciGm4
+qpd 8640
+contact kaveh@whisper.security


### PR DESCRIPTION
These logs were requested by their operators via the participate list.