### PR TITLE
Add production and new staging log for Sigstore

### DIFF
--- a/lists/staging/log-list-100qps-40klogs.1
+++ b/lists/staging/log-list-100qps-40klogs.1
@@ -63,3 +63,11 @@ contact google-ct-logs@googlegroups.com
 vkey log2025-alpha3.rekor.sigstage.dev+d3d3a70c+AZQ93VXPMmj9uZj7U/7CefQ9yy8RgYFv6mKzOseipjqp
 qpd 86400
 contact infra-dev (at) sigstore.dev
+
+vkey log2026-1.us-east4.rekor.sigstage.dev+3a727147+AbgD80fRkVDJLei3IO3XKcuwuGLPvoMUNhRUz1QVIRnz
+qpd 86400
+contact infra-dev (at) sigstore.dev
+
+vkey log2025-1.rekor.sigstore.dev+cf119915+AbfK5adZJxsI323FwGD2AJJ9F4i89cfDuLdGJBIYntuO
+qpd 86400
+contact infra-dev (at) sigstore.dev

--- a/lists/testing/log-list.1
+++ b/lists/testing/log-list.1
@@ -24,10 +24,6 @@ vkey sigsum.org/v1/tree/4e89cc51651f0d95f3c6127c15e1a42e3ddf7046c5b17b752689c402
 qpd 8640
 contact sigsum-logs (at) glasklarteknik.se | https://git.glasklar.is/glasklar/services/sigsum-logs/-/blob/main/instances/barreleye.md
 
-vkey log2025-alpha3.rekor.sigstage.dev+d3d3a70c+AZQ93VXPMmj9uZj7U/7CefQ9yy8RgYFv6mKzOseipjqp
-qpd 86400
-contact infra-dev (at) sigstore.dev
-
 vkey sigsum.org/v1/tree/1643169b32bef33a3f54f8a353b87c475d19b6223cbb106390d10a29978e1cba+57f71a6a+AUfkgWBtisunR6awU9bC0ZFgX7EiF11BChICqRQwq845
 qpd 8640
 contact services@mullvad.net | https://serviceberry.tlog.stagemole.eu/about


### PR DESCRIPTION
We've added a second log to our staging environment as part of a multi-regional deployment. Given the stability of the witness network, I'm also adding our production log and am looking forward to enabling witnessing!

I've removed our older staging log from the testing list, since we will just rely on the staging witnesses.